### PR TITLE
Update TON Taipei Workshop post with revised prize details

### DIFF
--- a/_posts/2023-08-30-2023-ton-taipei-workshop.md
+++ b/_posts/2023-08-30-2023-ton-taipei-workshop.md
@@ -147,11 +147,11 @@ featured: true
 
 ### 📜 **4.3. Demo Day 獎勵**
 
-**TON Workshop台北站 總獎金 3000 U🔥** 
+**TON Workshop台北站 總獎金 3000 USDT 🔥** 
 
-* 🥇第一名：1500 U
-* 🥈第二名：1000 Ｕ
-* 🥉第三名：500 U
+* 🥇 第一名：1500 USDT
+* 🥈 第二名：1000 USDT
+* 🥉 第三名：500 USDT
 
 🎁 *所有在 Demo Day （9/22）展示的團隊均可獲得 SafePal 贊助的 SafePal S1 冷錢包。*
 


### PR DESCRIPTION
The commit updates the TON Taipei Workshop post to reflect the revised prize details for Demo Day. The total prize pool is now 3000 USDT, with the first-place winner receiving 1500 USDT, the second-place winner receiving 1000 USDT, and the third-place winner receiving 500 USDT. Additionally, all teams presenting at Demo Day will receive a SafePal S1 cold wallet sponsored by SafePal.